### PR TITLE
Extend pages-methods.php

### DIFF
--- a/extensions/pages-methods.php
+++ b/extensions/pages-methods.php
@@ -36,3 +36,23 @@ $kirby->set('pages::method', 'inaccessibleBy', function($pages, $obj) {
     return !$page->isAccessibleBy($obj);
   });
 });
+
+/**
+ * Return all pages from the collection that are accessible by the current user.
+ *
+ * @param \Pages $pages Collection of pages.
+ * @param \User|\Role $obj User or role object.
+ * @return \Pages
+ */
+$kirby->set('pages::method', 'accessibleByCurrentUser', function($pages) {
+  if(site()->user()) {
+      // user logged in --> role
+      $role = site()->user()->role();
+  }
+  else {
+      // user not logged in --> create fake "guest" role
+      $role = new Role(['id' => 'firewall__guest', 'name' => 'Firewall Guest', 'panel' => false]);
+  }
+  
+  return $pages->accessibleBy($role);
+});


### PR DESCRIPTION
To get only the user accessible pages for the menu (in template files) with easy chaining like so

```
$page->children()->accessibleByCurrentUser()->visible()
```

I created another function for the pages object, that works directly with the current user role. As there is no role for a not logged in user and Kirby returns false if you ask for the user, I had to temporarily create one. In my code, I even created an extension for Kirby $site object with a function $site->userRole() that does lines 48-55 and returns role wether there is a logged in user or not.